### PR TITLE
Fixed the incorrect registration link

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,7 +26,7 @@ Details are available on the GitHub repositories of [BrainHack Nordic](https://g
 
 ### Contribute
 
-- [Register](https://goo.gl/de4J2P)
+- [Register](https://forms.gle/M9QMk2dtguJLmFJB7)
 - [Submit project ideas](https://github.com/openneuropet/outreach/issues/new?assignees=&labels=&template=brainhack-.md&title=%5BBrainHack%5D)
 
 ### Resources


### PR DESCRIPTION
The registration link at the bottom of the page (under Contribute) directs to the wrong place.  So I fixed it to the link that the Register button above (which I missed when I first looked) directs to.

Looking forward to it!